### PR TITLE
Define `failureMessage` to comply with `strict` mode

### DIFF
--- a/scsocket.js
+++ b/scsocket.js
@@ -185,6 +185,7 @@ SCSocket.prototype._onSCClose = function (code, data) {
     SCEmitter.prototype.emit.call(this, 'disconnect', code, data);
 
     if (!SCSocket.ignoreStatuses[code]) {
+      var failureMessage;
       if (data) {
         failureMessage = 'Socket connection failed: ' + data;
       } else {


### PR DESCRIPTION
In `strict` mode using `socketcluster-server@4.2.6` we receive the following error when a socket **closes**:

```
/Users/mirague/Projects/pigeon/node_modules/socketcluster-server/scsocket.js:191
        failureMessage = 'Socket connection failed for unknown reasons';
                       ^

ReferenceError: failureMessage is not defined
    at Emitter.SCSocket._onSCClose (/Users/mirague/Projects/pigeon/node_modules/socketcluster-server/scsocket.js:191:24)
    at WebSocket.<anonymous> (/Users/mirague/Projects/pigeon/node_modules/socketcluster-server/scsocket.js:70:10)
    at emitTwo (events.js:106:13)
    at WebSocket.emit (events.js:191:7)
    at WebSocket.cleanupWebsocketResources (/Users/mirague/Projects/pigeon/node_modules/socketcluster-server/node_modules/ws/lib/WebSocket.js:927:10)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:926:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

This is because `failureMessage` is never defined (`var failureMessage;`). 

This PR aims to address this issue https://github.com/SocketCluster/socketcluster-server/issues/5

@jondubois 