### PR TITLE
node-uuid version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "async": "1.5.0",
     "base64id": "0.1.0",
     "lodash": "3.10.1",
-    "node-uuid": "1.4.3",
+    "node-uuid": "1.4.x",
     "sc-auth": "3.0.x",
     "sc-domain": "1.x.x",
     "sc-emitter": "1.0.x",


### PR DESCRIPTION
This is due to: https://nodesecurity.io/advisories/93