### PR TITLE
Adds MIDDLEWARE_UNSUBSCRIBE handler

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -664,6 +664,7 @@ SCServer.prototype._passThroughMiddleware = function (options, cb) {
         cb(noPublishError, options.data);
       }
     } else if (event == this._unsubscribeEvent) {
+      request.channel = options.data;
       async.applyEachSeries(this._middleware[this.MIDDLEWARE_UNSUBSCRIBE], request,
         function (err) {
           if (callbackInvoked) {


### PR DESCRIPTION
I'm using the MIDDLEWARE_SUBSCRIBE event to send messages such as "player x has joined the conversation". However, there is currently no way to send "player x has left the conversation" using middleware in the same manner.
MIDDLEWARE_UNSUBSCRIBE does not allow for blocking, but instead prints a warning when blocking is attempted by the consuming implementation i.e. `next(true);` will not block the unsubscribe.
