### PR TITLE
fix: use uws@0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sc-formatter": "~3.0.0",
     "sc-simple-broker": "~2.0.0",
     "uuid": "3.0.1",
-    "uws": "0.13.0",
+    "uws": "0.14.1",
     "ws": "1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- uws@0.13.0 appears to have been removed from npm, use 0.14.1

closes #17