### PR TITLE
Fix: Removing clients data when client disconnect during authentication process

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -491,6 +491,9 @@ SCServer.prototype._handleSocketConnection = function (wsSocket, upgradeReq) {
     var signedAuthToken = data.authToken || null;
     clearTimeout(scSocket._handshakeTimeoutRef);
 
+    self.clients[id] = scSocket;
+    self.clientsCount++;
+
     self._processAuthToken(scSocket, signedAuthToken, function (err, isBadToken) {
       var status = {
         id: scSocket.id,
@@ -509,9 +512,6 @@ SCServer.prototype._handleSocketConnection = function (wsSocket, upgradeReq) {
         }
       }
       status.isAuthenticated = !!scSocket.authToken;
-
-      self.clients[id] = scSocket;
-      self.clientsCount++;
 
       scSocket.state = scSocket.OPEN;
       scSocket.exchange = scSocket.global = self.exchange;


### PR DESCRIPTION
There is a problem with removing clients data from `clients` and `clientsCount` variables in `scserver.js`. When `authEngine` is set and authentication process takes some time, user can refresh site or just close it until authentication process finished. 
When this situation occur, client data stays on the server and due to this we have wrong information about clients connected to the server.