### PR TITLE
Calls to async.applyEachSeries must include an explicit callback

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -743,7 +743,13 @@ SCServer.prototype._passThroughMiddleware = function (options, cb) {
               }
               cb(err, eventData);
             }
-          }
+          },
+          // If this callback function isn't provided, async.applyEachSeries
+          // will treat the previous argument (meant to be the next function
+          // passed to the middleware) as if it were the callback, and the
+          // middleware will be unfairly deprived of its next function
+          // (causing exceptions on calls to next() because next is undefined).
+          () => {}
         );
       }
     } else if (event == '#publish') {
@@ -784,7 +790,13 @@ SCServer.prototype._passThroughMiddleware = function (options, cb) {
                 });
               }
             }
-          }
+          },
+          // If this callback function isn't provided, async.applyEachSeries
+          // will treat the previous argument (meant to be the next function
+          // passed to the middleware) as if it were the callback, and the
+          // middleware will be unfairly deprived of its next function
+          // (causing exceptions on calls to next() because next is undefined).
+          () => {}
         );
       } else {
         var noPublishError = new InvalidActionError('Client publish feature is disabled');
@@ -814,7 +826,13 @@ SCServer.prototype._passThroughMiddleware = function (options, cb) {
           }
           cb(err, request.data);
         }
-      }
+      },
+      // If this callback function isn't provided, async.applyEachSeries
+      // will treat the previous argument (meant to be the next function
+      // passed to the middleware) as if it were the callback, and the
+      // middleware will be unfairly deprived of its next function
+      // (causing exceptions on calls to next() because next is undefined).
+      () => {}
     );
   }
 };
@@ -847,7 +865,13 @@ SCServer.prototype._passThroughAuthenticateMiddleware = function (options, cb) {
         }
         cb(err, isBadToken);
       }
-    }
+    },
+    // If this callback function isn't provided, async.applyEachSeries
+    // will treat the previous argument (meant to be the next function
+    // passed to the middleware) as if it were the callback, and the
+    // middleware will be unfairly deprived of its next function
+    // (causing exceptions on calls to next() because next is undefined).
+    () => {}
   );
 };
 
@@ -880,7 +904,13 @@ SCServer.prototype._passThroughHandshakeSCMiddleware = function (options, cb) {
         }
         cb(err, statusCode);
       }
-    }
+    },
+    // If this callback function isn't provided, async.applyEachSeries
+    // will treat the previous argument (meant to be the next function
+    // passed to the middleware) as if it were the callback, and the
+    // middleware will be unfairly deprived of its next function
+    // (causing exceptions on calls to next() because next is undefined).
+    () => {}
   );
 };
 
@@ -918,7 +948,13 @@ SCServer.prototype.verifyOutboundEvent = function (socket, eventName, eventData,
             cb(null, eventData);
           }
         }
-      }
+      },
+      // If this callback function isn't provided, async.applyEachSeries
+      // will treat the previous argument (meant to be the next function
+      // passed to the middleware) as if it were the callback, and the
+      // middleware will be unfairly deprived of its next function
+      // (causing exceptions on calls to next() because next is undefined).
+      () => {}
     );
   } else {
     cb(null, eventData);


### PR DESCRIPTION
When you call async.applyEachSeries with a sequence of arguments that ends in a function, it assumes that the final argument is a callback that should be triggered when the series is complete.

   https://caolan.github.io/async/docs.html#applyEachSeries

In the use cases fixed in this PR, async.applyEachSeries is used to call middleware where the final parameter to the middleware is the next function.

Since the next is a function, and was the final parameter to applyEachSeries, applyEachSeries assumed it was the optional callback that can be provided as a final parameter, and not the final parameter to be passed to the middleware.  When calling the middleware, undefined was sent in place of the next parameter.  Middleware that actually needed to call the next parameter received an undefined value.

This PR ensures that the next function is indeed passed as the final parameter to the middleware.

