### PR TITLE
fix: compatibility with webpack dynamic import

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -103,27 +103,7 @@ var SCServer = function (options) {
     EventEmitter.prototype.emit.call(self, 'ready');
   });
 
-  // Provide explicit strings in order to make dynamic `require` compatible with Webpack.
-  var wsEngine = undefined;
-  try {
-    switch(opts.wsEngine) {
-      case('ws'): {
-        wsEngine = require('ws');
-        break;
-      }
-      case('uws'): {
-        wsEngine = require('uws');
-        break;
-      }
-      default: {
-        // This won't work in Webpack, but will work elsewhere.
-        wsEngine = require(opts.wsEngine);
-        break;
-      }
-    }
-  } catch(e) {
-    if(!e instanceof InvalidOptionsError) throw new InvalidOptionsError('wsEngine is not installed.')
-  }
+  var wsEngine = typeof opts.wsEngine === 'string' ? require(opts.wsEngine) : opts.wsEngine;
   if (!wsEngine || !wsEngine.Server) {
     throw new InvalidOptionsError('The wsEngine option must be a path or module name which points ' +
       'to a valid WebSocket engine module with a compatible interface');

--- a/scserver.js
+++ b/scserver.js
@@ -103,7 +103,27 @@ var SCServer = function (options) {
     EventEmitter.prototype.emit.call(self, 'ready');
   });
 
-  var wsEngine = require(opts.wsEngine);
+  // Provide explicit strings in order to make dynamic `require` compatible with Webpack.
+  var wsEngine = undefined;
+  try {
+    switch(opts.wsEngine) {
+      case('ws'): {
+        wsEngine = require('ws');
+        break;
+      }
+      case('uws'): {
+        wsEngine = require('uws');
+        break;
+      }
+      default: {
+        // This won't work in Webpack, but will work elsewhere.
+        wsEngine = require(opts.wsEngine);
+        break;
+      }
+    }
+  } catch(e) {
+    if(!e instanceof InvalidOptionsError) throw new InvalidOptionsError('wsEngine is not installed.')
+  }
   if (!wsEngine || !wsEngine.Server) {
     throw new InvalidOptionsError('The wsEngine option must be a path or module name which points ' +
       'to a valid WebSocket engine module with a compatible interface');


### PR DESCRIPTION
Currently `socketcluster-server` can't be used with `webpack` due how it's dynamic import is implemented. In case of `require(var)` webpack doesn't bundle anything with it.

Webpack requires that `require` module name is a static string, or at least starts with static string. This PR provides explicit strings to dynamic `require` for compatibility with Webpack.

Please add any other compatible modules and review the error message.