### PR TITLE
Upgrade `ws` to support `maxPayload`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -385,7 +385,7 @@
         "sc-errors": "1.4.1",
         "sc-formatter": "3.0.2",
         "uuid": "3.2.1",
-        "ws": "5.1.1"
+        "ws": "6.1.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sc-simple-broker": "^2.1.3",
     "uuid": "3.2.1",
     "sc-uws": "^10.148.2",
-    "ws": "5.1.1"
+    "ws": "6.1.2"
   },
   "devDependencies": {
     "localStorage": "^1.0.3",


### PR DESCRIPTION
I see there's `maxPayload` introduced in `socketcluster` [here](https://github.com/SocketCluster/socketcluster/blob/49a81d774cb621fa6483a8cb47d0a852d4e32fa6/scworker.js#L226), but it's not supported by `sc-uws`. In `ws` the support [was added from `6.0`](https://github.com/websockets/ws/pull/1402#issuecomment-398168810).

I have an issue where some clients are sending payloads which exceed RAM limit of heroku dyno and it's crashing the instance. This option looks like a solution without adding nginx.

EDIT: Merging this is not a top priority as we can just copy ws locally and specify the path in `wsEngine` option. I checked it doesn't look to break anything, but still might be kept for a major release.