### PR TITLE
Assume port 443 instead of 80 for https origins.

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -636,7 +636,7 @@ SCServer.prototype.verifyHandshake = function (info, cb) {
   } else {
     try {
       var parts = url.parse(origin);
-      parts.port = parts.port || 80;
+      parts.port = parts.port || (parts.protocol === 'https:' ? 443 : 80);
       ok = ~this.origins.indexOf(parts.hostname + ':' + parts.port) ||
         ~this.origins.indexOf(parts.hostname + ':*') ||
         ~this.origins.indexOf('*:' + parts.port);


### PR DESCRIPTION
You can enable checking of the Origin header using the `origins` option to `new SocketCluster`, e.g.

```
origins: [ 'www.example.com:443' ]
```

However, this fails if the Origin header scheme is https and the header contains no port, e.g.

```
Origin: https://www.example.com
```

The check fails because if the header contains no port, the port defaults to 80, regardless of the scheme. This pull request changes the check to assume port 443 if the Origin header contains no port and the schema is https; otherwise, continue to assume port 80.