### PR TITLE
Support req.socket.setAuthToken in MIDDLEWARE_HANDSHAKE_SC

### DIFF
--- a/scserver.js
+++ b/scserver.js
@@ -534,6 +534,10 @@ SCServer.prototype._handleSocketConnection = function (wsSocket, upgradeReq) {
         scSocket.disconnect(statusCode);
         return;
       }
+      if (scSocket.signedAuthToken) {
+        // scSocket might become authenticated in HandshakeSCMiddleware
+        signedAuthToken = scSocket.signedAuthToken;
+      }
       self._processAuthToken(scSocket, signedAuthToken, function (err, isBadToken, oldState) {
         if (scSocket.state === scSocket.CLOSED) {
           return;

--- a/test/integration.js
+++ b/test/integration.js
@@ -2009,6 +2009,30 @@ describe('Integration tests', function () {
           done();
         });
       });
+
+      it('Should authenticate token and respond with isAuthenticated = true if req.socket.setAuthToken is called', function (done) {
+        var scSocket;
+
+        server.addMiddleware(server.MIDDLEWARE_HANDSHAKE_SC, function (req, next) {
+          scSocket = req.socket;
+          assert.equal(scSocket.authState, scSocket.UNAUTHENTICATED);
+          scSocket.setAuthToken({username: 'alice'});
+          next();
+        });
+
+        client = socketCluster.connect({
+          hostname: clientOptions.hostname,
+          port: portNumber,
+          multiplex: false
+        });
+
+        client.once('connect', function (data) {
+          assert.equal(scSocket.authState, scSocket.AUTHENTICATED);
+          assert.equal(data.isAuthenticated, true);
+          done();
+        });
+      });
+
     });
   });
 


### PR DESCRIPTION
Handshake http request might already have necessary
credentials to establish authentication, such as Authorization
header. In this case, it might be desirable to call
req.socket.setAuthToken within MIDDLEWARE_HANDSHAKE_SC even if
#handshake event doesn't have authToken from client.

This submission ensures handshake socket response contains
isAuthenticated=true for the above use case