### PR TITLE
FIX: transmitPublish not allowing interception

### DIFF
--- a/serversocket.js
+++ b/serversocket.js
@@ -760,6 +760,7 @@ AGServerSocket.prototype._processInboundPacket = async function (packet, message
     }
 
     if (isPublish) {
+      packet.data.data = newData;
       await this._processInboundPublishPacket(packet);
     }
 


### PR DESCRIPTION
In "MIDDLEWARE_INBOUND" middleware, "PUBLISH_IN" action type doesn´t change data when passing as parameter to function action.allow({ data: 'middleware message'}).
This problem appears only with "transmitPublish", "invokePublish" is working fine.

This change ensures middleware action updates "packet.data.data".