### PR TITLE
Bump base64id

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ let agServer = socketClusterServer.attach(httpServer, {
 
 (The MIT License)
 
-Copyright (c) 2013-2019 SocketCluster.io
+Copyright (c) 2013-2023 SocketCluster.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ag-request": "^1.0.0",
     "ag-simple-broker": "^5.0.0",
     "async-stream-emitter": "^4.0.0",
-    "base64id": "^1.0.0",
+    "base64id": "^2.0.0",
     "clone-deep": "^4.0.1",
     "sc-errors": "^2.0.1",
     "sc-formatter": "^3.0.3",


### PR DESCRIPTION
closes https://github.com/SocketCluster/socketcluster/issues/467
`npm run test` is happy

https://github.com/faeldt/base64id/compare/1.0.0...2.0.0